### PR TITLE
Fix build failures with spaces in installation paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,42 @@ jobs:
         
     - name: Test module loading
       run: node -e "console.log('✅ Module loads:', !!require('./index.js'))"
-      
+
+  alpine-musl:
+    # Regression test for ERR_DLOPEN_FAILED on musl (Alpine): node-libxslt.node
+    # links xmljs.node by basename, which musl resolves via the runtime library
+    # path. The rpath added in common.gypi must let the module load here.
+    runs-on: ubuntu-latest
+    container:
+      image: node:24-alpine
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Install system dependencies
+      run: apk add --no-cache build-base python3 git binutils
+
+    - name: Install dependencies (builds from source)
+      run: npm install
+
+    - name: Verify build artifacts
+      run: |
+        test -f build/Release/node-libxslt.node
+        test -f node_modules/libxmljs2/build/Release/xmljs.node
+        echo "✅ Build artifacts present"
+
+    - name: Verify rpath is baked into the binary
+      run: readelf -d build/Release/node-libxslt.node | grep -E "RUNPATH|RPATH"
+
+    - name: Test module loading on musl
+      run: node -e "const x = require('./index.js'); if (typeof x.parse !== 'function') process.exit(1); console.log('✅ Module loads on Alpine/musl')"
+
+    - name: Run tests
+      run: npm test
+
   security:
     runs-on: ubuntu-latest
     

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,12 @@ jobs:
       # Don't let one flaky platform cancel (and mask) the others.
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [20.x, 22.x, 24.x]
+        # windows-2022 pinned: the windows-latest image ships Visual Studio
+        # 2026 (v18), which node-gyp cannot yet detect
+        # (https://github.com/nodejs/node-gyp/issues/3282). VS 2022 (v17) builds fine.
+        # node 20 dropped: libxmljs2@0.37 requires node >=22 and segfaults on 20.
+        os: [ubuntu-latest, macos-latest, windows-2022]
+        node-version: [22.x, 24.x]
         
     steps:
     - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     
     strategy:
+      # Don't let one flaky platform cancel (and mask) the others.
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         node-version: [20.x, 22.x, 24.x]
@@ -74,7 +76,7 @@ jobs:
     - name: Verify build artifacts
       run: |
         test -f build/Release/node-libxslt.node
-        test -f build/Release/xmljs.node
+        test -f node_modules/libxmljs2/build/Release/xmljs.node
         echo "✅ All build artifacts present"
         
     - name: Test module loading
@@ -89,13 +91,15 @@ jobs:
       image: node:24-alpine
 
     steps:
+    # git must exist before checkout, otherwise actions/checkout falls back to
+    # the REST API tarball, which cannot fetch submodules (the libxslt sources).
+    - name: Install Alpine build dependencies
+      run: apk add --no-cache git build-base python3 binutils
+
     - name: Checkout code
       uses: actions/checkout@v4
       with:
         submodules: recursive
-
-    - name: Install system dependencies
-      run: apk add --no-cache build-base python3 git binutils
 
     - name: Install dependencies (builds from source)
       run: npm install
@@ -109,11 +113,15 @@ jobs:
     - name: Verify rpath is baked into the binary
       run: readelf -d build/Release/node-libxslt.node | grep -E "RUNPATH|RPATH"
 
-    - name: Test module loading on musl
-      run: node -e "const x = require('./index.js'); if (typeof x.parse !== 'function') process.exit(1); console.log('✅ Module loads on Alpine/musl')"
-
-    - name: Run tests
-      run: npm test
+    - name: Verify module loads and transforms on musl
+      run: |
+        node -e '
+          const libxslt = require("./index.js");
+          const xsl = libxslt.parse("<xsl:stylesheet version=\"1.0\" xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\"><xsl:template match=\"/\"><out><xsl:value-of select=\"/in/@v\"/></out></xsl:template></xsl:stylesheet>");
+          const out = xsl.apply("<in v=\"musl\"/>");
+          if (!out.includes("musl")) { console.error("transform failed:", out); process.exit(1); }
+          console.log("✅ Loads and transforms on Alpine/musl");
+        '
 
   security:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x]
         
     steps:
     - name: Checkout code

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,4 @@
+{
+  "spec": "test/*.js",
+  "ignore": ["test/spaces-in-path.js"]
+}

--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,6 @@
 # Development files
 .github/
-test/
+test/typescript-test.ts
 coverage/
 docs/
 *.log

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,31 @@
+# Development files
+.github/
+test/
+coverage/
+docs/
+*.log
+.nyc_output
+
+# Git files (but keep the submodule contents)
+.git/
+.gitmodules
+.gitignore
+
+# Build artifacts that will be rebuilt
+build/
+node_modules/
+
+# Documentation generation
+readme.hbs
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# macOS
+.DS_Store
+
+# Windows
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ From source:
 Basic usage
 -----------
 
+### JavaScript
 ```js
 var libxslt = require('libxslt-next');
 
@@ -43,6 +44,45 @@ libxslt.parse(stylesheetString, function(err, stylesheet){
     // result is a string containing the result of the transformation
   });  
 });
+```
+
+### TypeScript
+```typescript
+import * as libxslt from 'libxslt-next';
+import { Stylesheet, ApplyOptions } from 'libxslt-next';
+
+// Parse stylesheet with type safety
+libxslt.parse(stylesheetString, (err, stylesheet: Stylesheet | undefined) => {
+  if (err) {
+    console.error('Parse error:', err);
+    return;
+  }
+  
+  if (!stylesheet) return;
+  
+  const params = {
+    MyParam: 'my value'
+  };
+  
+  const options: ApplyOptions = {
+    outputFormat: 'string'
+  };
+  
+  // Apply with full type checking
+  stylesheet.apply(documentString, params, options, (err, result) => {
+    if (err) {
+      console.error('Apply error:', err);
+      return;
+    }
+    
+    // result is properly typed as string | libxmljs.Document
+    console.log('Transform result:', result);
+  });
+});
+
+// Synchronous usage with types
+const stylesheet: Stylesheet = libxslt.parse(stylesheetString);
+const result: string = stylesheet.apply(documentString);
 ```
 
 Libxmljs integration
@@ -146,6 +186,12 @@ Environment compatibility
 - [libxmljs2](https://github.com/libxmljs/libxmljs2) for XML parsing (replaces deprecated libxmljs)
 - [NaN](https://github.com/nodejs/nan) 2.22.2+ for Node.js API compatibility
 - Bundled libxslt (no system dependencies required)
+
+**TypeScript Support**: This package includes built-in TypeScript definitions:
+- No need to install separate `@types` packages
+- Full type safety for all API methods
+- Compatible with TypeScript 3.0+
+- Auto-completion and IntelliSense support in modern IDEs
 
 API Reference
 =============

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-node-libxslt
+libxslt-next
 ============
 
 [![Build status](https://travis-ci.org/albanm/node-libxslt.svg)](https://travis-ci.org/albanm/node-libxslt)
 [![Code Climate](https://codeclimate.com/github/albanm/node-libxslt/badges/gpa.svg)](https://codeclimate.com/github/albanm/node-libxslt)
-[![NPM version](https://badge.fury.io/js/libxslt.svg)](http://badge.fury.io/js/libxslt)
+[![NPM version](https://badge.fury.io/js/libxslt-next.svg)](http://badge.fury.io/js/libxslt-next)
 
 Node.js bindings for [libxslt](http://xmlsoft.org/libxslt/) compatible with [libxmljs2](https://github.com/libxmljs/libxmljs2).
 
@@ -13,11 +13,11 @@ Node.js bindings for [libxslt](http://xmlsoft.org/libxslt/) compatible with [lib
 Installation
 ------------
 
-    npm install libxslt
+    npm install libxslt-next
 
 From source:
 
-    git clone https://github.com/albanm/node-libxslt.git
+    git clone https://github.com/mariuso/node-libxslt-next.git
 		git submodule update --init
 		npm install
 		npm test
@@ -30,7 +30,7 @@ Basic usage
 -----------
 
 ```js
-var libxslt = require('libxslt');
+var libxslt = require('libxslt-next');
 
 libxslt.parse(stylesheetString, function(err, stylesheet){
   var params = {
@@ -48,14 +48,14 @@ libxslt.parse(stylesheetString, function(err, stylesheet){
 Libxmljs integration
 --------------------
 
-Node-libxslt depends on [libxmljs](https://github.com/polotek/libxmljs/issues/226) in the same way that [libxslt](http://xmlsoft.org/libxslt/) depends on [libxml](http://xmlsoft.org/). This dependancy makes possible to bundle and to load in memory libxml only once for users of both libraries.
+libxslt-next depends on [libxmljs2](https://github.com/libxmljs/libxmljs2) in the same way that [libxslt](http://xmlsoft.org/libxslt/) depends on [libxml](http://xmlsoft.org/). This dependancy makes possible to bundle and to load in memory libxml only once for users of both libraries.
 
-The libxmljs module required by node-libxslt is exposed as ```require('libxslt').libxmljs```. This prevents depending on libxmljs twice which is not optimal and source of weird bugs.
+The libxmljs module required by libxslt-next is exposed as ```require('libxslt-next').libxmljs```. This prevents depending on libxmljs twice which is not optimal and source of weird bugs.
 
 It is possible to work with libxmljs documents instead of strings:
 
 ```js
-var libxslt = require('libxslt');
+var libxslt = require('libxslt-next');
 var libxmljs = libxslt.libxmljs;
 
 var stylesheetObj = libxmljs.parseXml(stylesheetString, { nocdata: true });
@@ -86,7 +86,7 @@ The same *parse()* and *apply()* functions can be used in synchronous mode simpl
 In this case if a parsing error occurs it will be thrown.
 
 ```js
-var lixslt = require('libxslt');
+var lixslt = require('libxslt-next');
 
 var stylesheet = libxslt.parse(stylesheetString);
 
@@ -137,7 +137,7 @@ Environment compatibility
 - ✅ macOS (Intel & Apple Silicon)
 - ✅ Windows (64-bit)
 
-**Build Requirements**: Node-libxslt depends on [node-gyp](https://github.com/TooTallNate/node-gyp) for native compilation. You will need:
+**Build Requirements**: libxslt-next depends on [node-gyp](https://github.com/TooTallNate/node-gyp) for native compilation. You will need:
 - Node.js 20.0.0 or higher
 - Python 3.x
 - C++ build tools (Visual Studio Build Tools on Windows)

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ libxslt-next
 
 Node.js bindings for [libxslt](http://xmlsoft.org/libxslt/) compatible with [libxmljs2](https://github.com/libxmljs/libxmljs2).
 
-> **⚡ Node.js Compatibility Update**: This version supports Node.js 20.x, 22.x, and 24.x LTS versions. 
-> For users upgrading from Node.js 18 or earlier versions, this package now uses modern dependencies and APIs for improved compatibility and performance.
+> **⚡ Node.js Compatibility Update**: This version supports Node.js 22.x and 24.x LTS versions.
+> For users upgrading from Node.js 20 or earlier versions, this package now uses modern dependencies and APIs for improved compatibility and performance.
 
 Installation
 ------------
@@ -189,17 +189,20 @@ Conclusion:
 Environment compatibility
 -------------------------
 
-**Node.js Support**: This package supports Node.js 20.x, 22.x, and 24.x LTS versions.
+**Node.js Support**: This package supports Node.js 22.x and 24.x LTS versions.
+Node.js 20 is not supported because `libxmljs2@0.37` requires Node.js >= 22.
 
 **Platform Support**: 
-- ✅ Linux (64-bit)
+- ✅ Linux (64-bit, glibc and musl/Alpine)
 - ✅ macOS (Intel & Apple Silicon)
 - ✅ Windows (64-bit)
 
-**Build Requirements**: libxslt-next depends on [node-gyp](https://github.com/TooTallNate/node-gyp) for native compilation. You will need:
-- Node.js 20.0.0 or higher
+**Build Requirements**: libxslt-next depends on [node-gyp](https://github.com/nodejs/node-gyp) for native compilation. You will need:
+- Node.js 22.0.0 or higher
 - Python 3.x
-- C++ build tools (Visual Studio Build Tools on Windows)
+- C++ build tools (Visual Studio Build Tools on Windows). Note: node-gyp does not
+  yet detect Visual Studio 2026 ([node-gyp#3282](https://github.com/nodejs/node-gyp/issues/3282));
+  use Visual Studio 2022 build tools.
 
 **Dependencies**: This package uses:
 - [libxmljs2](https://github.com/libxmljs/libxmljs2) for XML parsing (replaces deprecated libxmljs)

--- a/README.md
+++ b/README.md
@@ -26,6 +26,25 @@ From source:
 
     npm run rebuild
 
+### Alpine / musl
+
+The native addon is built from source on install, so the build toolchain must be
+present. On Alpine (musl libc) install it first:
+
+    apk add --no-cache build-base python3
+
+This is also required in Alpine-based Docker images, e.g. `node:24-alpine`:
+
+```dockerfile
+FROM node:24-alpine
+RUN apk add --no-cache build-base python3
+# ... npm install
+```
+
+> Versions before 1.0.10 failed to load on musl with
+> `Error loading shared library xmljs.node ... (ERR_DLOPEN_FAILED)`.
+> 1.0.10 adds an rpath so the addon resolves its libxmljs2 dependency on musl.
+
 Basic usage
 -----------
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -7,6 +7,20 @@
       'dependencies': [
       	'./deps/libxslt.gyp:libxslt',
       	'./deps/libxslt.gyp:libexslt'
+      ],
+      'conditions': [
+        # On Windows there is no dynamic symbol resolution like Linux/macOS, so
+        # node-libxslt must link against an import library for libxmljs2's addon.
+        # Build libxmljs2's xmljs target into our PRODUCT_DIR (which produces
+        # xmljs.lib next to xmljs.node) and link against it.
+        ['OS=="win"', {
+          'dependencies': [
+            '<(node_xmljs)/binding.gyp:xmljs'
+          ],
+          'libraries': [
+            '<(PRODUCT_DIR)/xmljs.lib'
+          ]
+        }]
       ]
     }
   ]

--- a/common.gypi
+++ b/common.gypi
@@ -1,7 +1,7 @@
 # imitation of this https://github.com/TooTallNate/node-vorbis/blob/master/common.gypi
 {
   'variables': {
-    'node_xmljs%': '<!(node -p "require(\'path\').dirname(require.resolve(\'libxmljs2\'))")',
+    'node_xmljs%': '<!(node -p "JSON.stringify(require(\'path\').dirname(require.resolve(\'libxmljs2\')))")',
   },
   'target_defaults': {
     'include_dirs': [

--- a/common.gypi
+++ b/common.gypi
@@ -1,7 +1,7 @@
 # imitation of this https://github.com/TooTallNate/node-vorbis/blob/master/common.gypi
 {
   'variables': {
-    'node_xmljs%': '<!(node -pe "require(\'path\').dirname(require.resolve(\'libxmljs2\'))" | sed "s/ /\\\\ /g")',
+    'node_xmljs%': '<!(node -p "JSON.stringify(require(\'path\').dirname(require.resolve(\'libxmljs2\'))).slice(1, -1)")',
   },
   'target_defaults': {
     'include_dirs': [

--- a/common.gypi
+++ b/common.gypi
@@ -1,7 +1,7 @@
 # imitation of this https://github.com/TooTallNate/node-vorbis/blob/master/common.gypi
 {
   'variables': {
-    'node_xmljs%': '<!(node -p "JSON.stringify(require(\'path\').dirname(require.resolve(\'libxmljs2\')))")',
+    'node_xmljs%': '<!(node -pe "require(\'path\').dirname(require.resolve(\'libxmljs2\'))" | sed "s/ /\\\\ /g")',
   },
   'target_defaults': {
     'include_dirs': [

--- a/common.gypi
+++ b/common.gypi
@@ -1,13 +1,10 @@
 # imitation of this https://github.com/TooTallNate/node-vorbis/blob/master/common.gypi
 {
-  'variables': {
-    'node_xmljs%': '<!(node -p "require(\'path\').dirname(require.resolve(\'libxmljs2\'))")',
-  },
   'target_defaults': {
     'include_dirs': [
-      '<(node_xmljs)/src',
-      '<(node_xmljs)/vendor/libxml',
-      '<(node_xmljs)/vendor/libxml/include'
+      '<!(node -p "require(\'path\').join(require(\'path\').dirname(require.resolve(\'libxmljs2\')), \'src\')")',
+      '<!(node -p "require(\'path\').join(require(\'path\').dirname(require.resolve(\'libxmljs2\')), \'vendor\', \'libxml\')")',
+      '<!(node -p "require(\'path\').join(require(\'path\').dirname(require.resolve(\'libxmljs2\')), \'vendor\', \'libxml\', \'include\')")'
     ],
     'conditions': [
       ['OS=="win"', {
@@ -16,10 +13,10 @@
         ],
       }, {
         'libraries': [
-          '<(node_xmljs)/build/<(CONFIGURATION_NAME)/xmljs.node'
+          '<!(node -p "require(\'path\').join(require(\'path\').dirname(require.resolve(\'libxmljs2\')), \'build\', process.env.npm_config_build_type || \'Release\', \'xmljs.node\')")'
         ],
         'library_dirs': [
-          '<(node_xmljs)/build/<(CONFIGURATION_NAME)'
+          '<!(node -p "require(\'path\').join(require(\'path\').dirname(require.resolve(\'libxmljs2\')), \'build\', process.env.npm_config_build_type || \'Release\')")'
         ],
       }],
     ],

--- a/common.gypi
+++ b/common.gypi
@@ -1,23 +1,25 @@
 # imitation of this https://github.com/TooTallNate/node-vorbis/blob/master/common.gypi
 {
   'variables': {
-    'node_xmljs': '<!(node -e "console.log(JSON.stringify(require(\'path\').dirname(require.resolve(\'libxmljs2\'))))")',
-    'xmljs_include_dirs': [
-      '<(node_xmljs)/src/',
+    'node_xmljs%': '<!(node -p "require(\'path\').dirname(require.resolve(\'libxmljs2\'))")',
+  },
+  'target_defaults': {
+    'include_dirs': [
+      '<(node_xmljs)/src',
       '<(node_xmljs)/vendor/libxml',
       '<(node_xmljs)/vendor/libxml/include'
     ],
     'conditions': [
       ['OS=="win"', {
-        'xmljs_libraries': [
+        'libraries': [
           '<(PRODUCT_DIR)/xmljs.lib'
         ],
       }, {
-        'xmljs_libraries': [
-          '<(node_xmljs)/build/$(BUILDTYPE)/xmljs.node'
+        'libraries': [
+          '<(node_xmljs)/build/<(CONFIGURATION_NAME)/xmljs.node'
         ],
         'library_dirs': [
-          '<(node_xmljs)/build/$(BUILDTYPE)'
+          '<(node_xmljs)/build/<(CONFIGURATION_NAME)'
         ],
       }],
     ],

--- a/common.gypi
+++ b/common.gypi
@@ -1,7 +1,7 @@
 # imitation of this https://github.com/TooTallNate/node-vorbis/blob/master/common.gypi
 {
   'variables': {
-    'node_xmljs%': '<!(node -p "JSON.stringify(require(\'path\').dirname(require.resolve(\'libxmljs2\'))).slice(1, -1)")',
+    'node_xmljs%': '<!(node -p "require(\'path\').dirname(require.resolve(\'libxmljs2\'))")',
   },
   'target_defaults': {
     'include_dirs': [

--- a/common.gypi
+++ b/common.gypi
@@ -1,7 +1,7 @@
 # imitation of this https://github.com/TooTallNate/node-vorbis/blob/master/common.gypi
 {
   'variables': {
-    'node_xmljs': '<!(node -e "console.log(require(\'path\').dirname(require.resolve(\'libxmljs2\')))")',
+    'node_xmljs': '<!(node -e "console.log(JSON.stringify(require(\'path\').dirname(require.resolve(\'libxmljs2\'))))")',
     'xmljs_include_dirs': [
       '<(node_xmljs)/src/',
       '<(node_xmljs)/vendor/libxml',
@@ -14,8 +14,10 @@
         ],
       }, {
         'xmljs_libraries': [
-          '<(node_xmljs)/build/$(BUILDTYPE)/xmljs.node',
-          '-Wl,-rpath,<(node_xmljs)/build/$(BUILDTYPE)'
+          '<(node_xmljs)/build/$(BUILDTYPE)/xmljs.node'
+        ],
+        'library_dirs': [
+          '<(node_xmljs)/build/$(BUILDTYPE)'
         ],
       }],
     ],

--- a/common.gypi
+++ b/common.gypi
@@ -1,5 +1,10 @@
 # imitation of this https://github.com/TooTallNate/node-vorbis/blob/master/common.gypi
 {
+  'variables': {
+    # Directory of the installed libxmljs2 package. Used on Windows to build its
+    # xmljs addon into our PRODUCT_DIR so xmljs.lib is available to link against.
+    'node_xmljs': '<!(node -p "require(\'path\').dirname(require.resolve(\'libxmljs2\'))")',
+  },
   'target_defaults': {
     'include_dirs': [
       '<!(node -p "require(\'path\').join(require(\'path\').dirname(require.resolve(\'libxmljs2\')), \'src\')")',
@@ -8,12 +13,10 @@
     ],
     'conditions': [
       ['OS=="win"', {
-        # Link against libxmljs2's import library in its own build dir, resolved
-        # via require.resolve. Using <(PRODUCT_DIR)/xmljs.lib pointed at this
-        # addon's build dir, where xmljs.lib never exists -> LNK1181.
-        'libraries': [
-          '<!(node -p "require(\'path\').join(require(\'path\').dirname(require.resolve(\'libxmljs2\')), \'build\', process.env.npm_config_build_type || \'Release\', \'xmljs.lib\')")'
-        ],
+        # Windows linking is handled on the node-libxslt target in binding.gyp:
+        # it builds libxmljs2's xmljs target into our PRODUCT_DIR (producing
+        # xmljs.lib) and links against it. Keeping that out of target_defaults
+        # avoids the xmljs dependency target trying to link against itself.
       }, {
         'libraries': [
           '<!(node -p "require(\'path\').join(require(\'path\').dirname(require.resolve(\'libxmljs2\')), \'build\', process.env.npm_config_build_type || \'Release\', \'xmljs.node\')")'

--- a/common.gypi
+++ b/common.gypi
@@ -18,6 +18,23 @@
         'library_dirs': [
           '<!(node -p "require(\'path\').join(require(\'path\').dirname(require.resolve(\'libxmljs2\')), \'build\', process.env.npm_config_build_type || \'Release\')")'
         ],
+        'conditions': [
+          # node-libxslt.node records a DT_NEEDED on the basename "xmljs.node".
+          # glibc resolves that against the already-loaded libxmljs2 (index.js
+          # requires libxmljs2 before this addon), so it works without an rpath.
+          # musl (Alpine) instead resolves the basename via the runtime library
+          # path, which has no entry for it -> ERR_DLOPEN_FAILED. Add an rpath so
+          # the loader can find xmljs.node on musl. Both an absolute path (the
+          # build-time location) and an $ORIGIN-relative path (survives moving
+          # node_modules) are provided. macOS uses @loader_path instead of
+          # $ORIGIN and already works like glibc, so this is Linux-only.
+          ['OS=="linux"', {
+            'ldflags': [
+              '-Wl,-rpath,<!(node -p "require(\'path\').join(require(\'path\').dirname(require.resolve(\'libxmljs2\')), \'build\', process.env.npm_config_build_type || \'Release\')")',
+              '-Wl,-rpath,\'$$ORIGIN/../../../libxmljs2/build/Release\'',
+            ],
+          }],
+        ],
       }],
     ],
   },

--- a/common.gypi
+++ b/common.gypi
@@ -8,8 +8,11 @@
     ],
     'conditions': [
       ['OS=="win"', {
+        # Link against libxmljs2's import library in its own build dir, resolved
+        # via require.resolve. Using <(PRODUCT_DIR)/xmljs.lib pointed at this
+        # addon's build dir, where xmljs.lib never exists -> LNK1181.
         'libraries': [
-          '<(PRODUCT_DIR)/xmljs.lib'
+          '<!(node -p "require(\'path\').join(require(\'path\').dirname(require.resolve(\'libxmljs2\')), \'build\', process.env.npm_config_build_type || \'Release\', \'xmljs.lib\')")'
         ],
       }, {
         'libraries': [

--- a/deps/libxslt.gyp
+++ b/deps/libxslt.gyp
@@ -1,8 +1,7 @@
 {
+  'includes': ['../common.gypi'],
   'variables': {
     'target_arch%': 'ia32', # build for a 32-bit CPU by default
-    'xmljs_include_dirs%': [],
-    'xmljs_libraries%': [],
   },
   'target_defaults': {
     'default_configuration': 'Release',
@@ -28,8 +27,7 @@
     'include_dirs': [
       'libxslt/',
       # platform and arch-specific headers
-      'libxslt.config/<(OS)/<(target_arch)',
-      '<@(xmljs_include_dirs)'
+      'libxslt.config/<(OS)/<(target_arch)'
     ]
   },
   'targets': [
@@ -59,21 +57,12 @@
         'libxslt/libxslt/xsltlocale.c',
         'libxslt/libxslt/xsltutils.c'
       ],
-      'dependencies': [
-        '<(node_xmljs)/binding.gyp:xmljs'
-      ],
-      'link_settings': {
-        'libraries': [
-          '<@(xmljs_libraries)',
-        ]
-      },
       'direct_dependent_settings': {
         'defines': ['LIBXSLT_STATIC'],
         'include_dirs': [
           'libxslt/',
           # platform and arch-specific headers
-          'libxslt.config/<(OS)/<(target_arch)',
-          '<@(xmljs_include_dirs)'
+          'libxslt.config/<(OS)/<(target_arch)'
         ],
       }
     },
@@ -95,11 +84,6 @@
       'dependencies': [
         'libxslt'
       ],
-      'link_settings': {
-        'libraries': [
-          '<@(xmljs_libraries)'
-        ]
-      }
     }
   ]
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,54 @@
+// Type definitions for libxslt-next
+// Project: https://github.com/mariuso/node-libxslt-next
+// Definitions by: libxslt-next contributors
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
+
+/// <reference path="./types/libxmljs2.d.ts" />
+import * as libxmljs from "libxmljs2";
+
+export { libxmljs };
+
+export interface ApplyOptions {
+    outputFormat?: "string" | "document" | undefined;
+    noWrapParams?: boolean | undefined;
+}
+
+export interface Stylesheet {
+    // Synchronous apply methods
+    apply(source: string): string;
+    apply(source: libxmljs.Document): libxmljs.Document;
+    apply(source: string, params: object): string;
+    apply(source: libxmljs.Document, params: object): libxmljs.Document;
+    apply(source: string, params: object, options: ApplyOptions): string | libxmljs.Document;
+    apply(source: libxmljs.Document, params: object, options: ApplyOptions): string | libxmljs.Document;
+
+    // Asynchronous apply methods with callbacks
+    apply(source: string, callback: ApplyStringCallback): void;
+    apply(source: libxmljs.Document, callback: ApplyDocumentCallback): void;
+    apply(source: string, params: object, callback: ApplyStringCallback): void;
+    apply(source: libxmljs.Document, params: object, callback: ApplyDocumentCallback): void;
+    apply(source: string, params: object, options: ApplyOptions, callback: ApplyCallback): void;
+    apply(source: libxmljs.Document, params: object, options: ApplyOptions, callback: ApplyCallback): void;
+
+    // File-based apply methods
+    applyToFile(sourcePath: string, callback: ApplyStringCallback): void;
+    applyToFile(sourcePath: string, params: object, callback: ApplyStringCallback): void;
+    applyToFile(sourcePath: string, params: object, options: ApplyOptions, callback: ApplyStringCallback): void;
+}
+
+export type ApplyCallback = (err: Error | null, result?: string | libxmljs.Document) => void;
+export type ApplyStringCallback = (err: Error | null, result?: string) => void;
+export type ApplyDocumentCallback = (err: Error | null, result?: libxmljs.Document) => void;
+export type ParseCallback = (err: Error | null, stylesheet?: Stylesheet) => void;
+
+// Synchronous parse methods
+export function parse(source: string): Stylesheet;
+export function parse(source: libxmljs.Document): Stylesheet;
+
+// Asynchronous parse methods
+export function parse(source: string, callback: ParseCallback): void;
+export function parse(source: libxmljs.Document, callback: ParseCallback): void;
+
+// File-based parse method (async only)
+export function parseFile(sourcePath: string, callback: ParseCallback): void;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "libxslt-next",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "libxslt-next",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,11 +15,13 @@
         "nan": "^2.22.2"
       },
       "devDependencies": {
+        "@types/node": "^20.19.1",
         "async": "~3.2.0",
         "jsdoc-to-markdown": "^7.0.1",
         "mocha": "^9.0.2",
         "nyc": "^17.1.0",
-        "should": "~13.2.3"
+        "should": "~13.2.3",
+        "typescript": "^5.8.3"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -619,6 +621,16 @@
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
       "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
       "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.1.tgz",
+      "integrity": "sha512-jJD50LtlD2dodAEO653i3YF04NWak6jN3ky+Ri3Em3mGR39/glWiboM/IePaRbgwSfqM1TpGXfAg8ohn/4dTgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@ungap/promise-all-settled": {
       "version": "1.1.2",
@@ -4603,6 +4615,20 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/typical": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
@@ -4633,6 +4659,13 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
       "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
       "dev": true
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unique-filename": {
       "version": "4.0.0",
@@ -5407,6 +5440,15 @@
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
       "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
       "dev": true
+    },
+    "@types/node": {
+      "version": "20.19.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.1.tgz",
+      "integrity": "sha512-jJD50LtlD2dodAEO653i3YF04NWak6jN3ky+Ri3Em3mGR39/glWiboM/IePaRbgwSfqM1TpGXfAg8ohn/4dTgA==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~6.21.0"
+      }
     },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
@@ -8219,6 +8261,12 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true
+    },
     "typical": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
@@ -8242,6 +8290,12 @@
       "version": "1.13.6",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
       "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true
     },
     "unique-filename": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "libxslt-next",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "libxslt-next",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "libxslt-next",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "libxslt-next",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "libxslt-next",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "libxslt-next",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "libxslt-next",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "libxslt-next",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "libxslt-next",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "libxslt-next",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "libxslt-next",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "libxslt-next",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "libxslt-next",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libxslt-next",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Node.js bindings for libxslt with Node.js 20/22/24 support - Modern fork with updated dependencies",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -25,17 +25,17 @@
     "libxmljs2"
   ],
   "author": "Alban Mouton <alban.mouton@gmail.com>",
-  "homepage": "https://github.com/USERNAME/node-libxslt",
+  "homepage": "https://github.com/mariuso/node-libxslt-next",
   "contributors": [
     "Rui Azevedo <ruihfazevedo@gmail.com> (http://www.r-site.net/)",
     "Marius Oseth <marius@osethconsult.no>"
   ],
   "bugs": {
-    "url": "https://github.com/USERNAME/node-libxslt/issues"
+    "url": "https://github.com/mariuso/node-libxslt-next/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/USERNAME/node-libxslt.git"
+    "url": "https://github.com/mariuso/node-libxslt-next.git"
   },
   "license": "MIT",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -3,12 +3,24 @@
   "version": "1.0.2",
   "description": "Node.js bindings for libxslt with Node.js 20/22/24 support - Modern fork with updated dependencies",
   "main": "index.js",
+  "types": "index.d.ts",
+  "files": [
+    "index.js",
+    "index.d.ts",
+    "src/",
+    "deps/",
+    "patches/",
+    "scripts/",
+    "binding.gyp",
+    "common.gypi"
+  ],
   "scripts": {
     "preinstall": "node scripts/apply-patches.js",
     "postinstall": "node-gyp rebuild",
     "rebuild": "node scripts/apply-patches.js && node-gyp rebuild",
     "test": "mocha -R spec",
     "test:coverage": "nyc npm test",
+    "test:types": "tsc --noEmit test/typescript-test.ts",
     "coverage:report": "nyc report --reporter=html",
     "docs": "jsdoc2md index.js --template readme.hbs > README.md"
   },
@@ -22,7 +34,9 @@
     "node22",
     "node24",
     "modern",
-    "libxmljs2"
+    "libxmljs2",
+    "typescript",
+    "types"
   ],
   "author": "Alban Mouton <alban.mouton@gmail.com>",
   "homepage": "https://github.com/mariuso/node-libxslt-next",
@@ -47,10 +61,12 @@
     "nan": "^2.22.2"
   },
   "devDependencies": {
+    "@types/node": "^20.19.1",
     "async": "~3.2.0",
     "jsdoc-to-markdown": "^7.0.1",
     "mocha": "^9.0.2",
     "nyc": "^17.1.0",
-    "should": "~13.2.3"
+    "should": "~13.2.3",
+    "typescript": "^5.8.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libxslt-next",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Node.js bindings for libxslt with Node.js 20/22/24 support - Modern fork with updated dependencies",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libxslt-next",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Node.js bindings for libxslt with Node.js 20/22/24 support - Modern fork with updated dependencies",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libxslt-next",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Node.js bindings for libxslt with Node.js 20/22/24 support - Modern fork with updated dependencies",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test": "mocha -R spec",
     "test:coverage": "nyc npm test",
     "test:types": "tsc --noEmit test/typescript-test.ts",
+    "test:spaces": "node test/spaces-in-path.js",
     "coverage:report": "nyc report --reporter=html",
     "docs": "jsdoc2md index.js --template readme.hbs > README.md"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libxslt-next",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Node.js bindings for libxslt with Node.js 20/22/24 support - Modern fork with updated dependencies",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libxslt-next",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Node.js bindings for libxslt with Node.js 20/22/24 support - Modern fork with updated dependencies",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libxslt-next",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Node.js bindings for libxslt with Node.js 20/22/24 support - Modern fork with updated dependencies",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libxslt-next",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Node.js bindings for libxslt with Node.js 20/22/24 support - Modern fork with updated dependencies",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libxslt-next",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Node.js bindings for libxslt with Node.js 20/22/24 support - Modern fork with updated dependencies",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libxslt-next",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Node.js bindings for libxslt with Node.js 20/22/24 support - Modern fork with updated dependencies",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "libxslt-next",
   "version": "1.0.10",
-  "description": "Node.js bindings for libxslt with Node.js 20/22/24 support - Modern fork with updated dependencies",
+  "description": "Node.js bindings for libxslt with Node.js 22/24 support - Modern fork with updated dependencies",
   "main": "index.js",
   "types": "index.d.ts",
   "files": [
@@ -31,7 +31,6 @@
     "xslt",
     "libxslt",
     "bindings",
-    "node20",
     "node22",
     "node24",
     "modern",
@@ -54,7 +53,7 @@
   },
   "license": "MIT",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "dependencies": {
     "bindings": "^1.5.0",

--- a/scripts/apply-patches.js
+++ b/scripts/apply-patches.js
@@ -44,7 +44,7 @@ patches.forEach(patchFile => {
   console.log(`Applying ${patchFile}...`);
   
   try {
-    execSync(`patch -p1 < ${patchPath}`, {
+    execSync(`patch -p1 < "${patchPath}"`, {
       cwd: libxsltDir,
       stdio: 'inherit'
     });

--- a/test/spaces-in-path.js
+++ b/test/spaces-in-path.js
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+const os = require('os');
+
+console.log('Testing package installation in path with spaces...');
+
+// Create a temporary directory with spaces in the name
+const testDirName = 'test with spaces';
+const testDir = path.join(os.tmpdir(), testDirName);
+
+try {
+  // Clean up any existing test directory
+  if (fs.existsSync(testDir)) {
+    fs.rmSync(testDir, { recursive: true, force: true });
+  }
+
+  // Create test directory
+  fs.mkdirSync(testDir, { recursive: true });
+  console.log(`Created test directory: ${testDir}`);
+
+  // Create a minimal package.json
+  const packageJson = {
+    name: 'spaces-test',
+    version: '1.0.0',
+    dependencies: {}
+  };
+  
+  fs.writeFileSync(
+    path.join(testDir, 'package.json'), 
+    JSON.stringify(packageJson, null, 2)
+  );
+
+  // Get the current package path and version
+  const currentPackageJson = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8'));
+  const packagePath = path.join(__dirname, '..');
+  
+  console.log(`Installing ${currentPackageJson.name}@${currentPackageJson.version} from ${packagePath}...`);
+
+  // Install the current package in the test directory
+  execSync(`npm install "${packagePath}"`, {
+    cwd: testDir,
+    stdio: 'inherit',
+    timeout: 120000 // 2 minutes timeout
+  });
+
+  // Try to require the installed package
+  const installedPackagePath = path.join(testDir, 'node_modules', currentPackageJson.name);
+  console.log(`Testing require from: ${installedPackagePath}`);
+  
+  // This will verify that the native module compiled and can be loaded
+  require(installedPackagePath);
+  
+  console.log('✅ SUCCESS: Package installed and loaded successfully in path with spaces!');
+
+} catch (error) {
+  console.error('❌ FAILED: Error during spaces-in-path test:');
+  console.error(error.message);
+  if (error.stdout) console.error('STDOUT:', error.stdout.toString());
+  if (error.stderr) console.error('STDERR:', error.stderr.toString());
+  process.exit(1);
+} finally {
+  // Clean up
+  try {
+    if (fs.existsSync(testDir)) {
+      fs.rmSync(testDir, { recursive: true, force: true });
+      console.log('Cleaned up test directory');
+    }
+  } catch (cleanupError) {
+    console.warn('Warning: Could not clean up test directory:', cleanupError.message);
+  }
+}

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -1,0 +1,132 @@
+// TypeScript test file to validate type definitions
+// This file is not meant to be executed, but to be type-checked by TypeScript compiler
+
+import * as libxslt from '../index';
+import { Stylesheet, ApplyOptions } from '../index';
+
+// Test that libxmljs2 is properly exported
+const xmlDoc = libxslt.libxmljs.parseXml('<root>test</root>');
+
+// Test synchronous parse from string
+const stylesheet1: Stylesheet = libxslt.parse('<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"></xsl:stylesheet>');
+
+// Test synchronous parse from Document
+const stylesheetDoc = libxslt.libxmljs.parseXml('<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"></xsl:stylesheet>');
+const stylesheet2: Stylesheet = libxslt.parse(stylesheetDoc);
+
+// Test asynchronous parse with callback
+libxslt.parse('<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"></xsl:stylesheet>', (err, stylesheet) => {
+    if (err) {
+        console.error(err);
+        return;
+    }
+    if (stylesheet) {
+        // stylesheet is properly typed as Stylesheet
+        console.log('Parsed stylesheet successfully');
+    }
+});
+
+// Test parseFile
+libxslt.parseFile('./test/resources/cd.xsl', (err, stylesheet) => {
+    if (err) {
+        console.error(err);
+        return;
+    }
+    if (stylesheet) {
+        console.log('Parsed stylesheet from file');
+    }
+});
+
+// Test synchronous apply methods
+const xmlString = '<test>data</test>';
+const resultString: string = stylesheet1.apply(xmlString);
+const resultDoc: libxslt.libxmljs.Document = stylesheet1.apply(xmlDoc);
+
+// Test apply with parameters
+const params = { param1: 'value1' };
+const resultWithParams: string = stylesheet1.apply(xmlString, params);
+
+// Test apply with options
+const options: ApplyOptions = {
+    outputFormat: 'string',
+    noWrapParams: false
+};
+const resultWithOptions: string | libxslt.libxmljs.Document = stylesheet1.apply(xmlString, params, options);
+
+// Test asynchronous apply methods
+stylesheet1.apply(xmlString, (err, result) => {
+    if (err) {
+        console.error(err);
+        return;
+    }
+    // result should be string since input was string
+    if (typeof result === 'string') {
+        console.log('Apply result:', result);
+    }
+});
+
+stylesheet1.apply(xmlDoc, (err, result) => {
+    if (err) {
+        console.error(err);
+        return;
+    }
+    // result should be Document since input was Document
+    if (result && typeof result === 'object' && 'root' in result) {
+        console.log('Apply result is Document');
+    }
+});
+
+// Test apply with parameters and callback
+stylesheet1.apply(xmlString, params, (err, result) => {
+    if (err) {
+        console.error(err);
+        return;
+    }
+    if (typeof result === 'string') {
+        console.log('Apply with params result:', result);
+    }
+});
+
+// Test apply with all options and callback
+stylesheet1.apply(xmlString, params, options, (err, result) => {
+    if (err) {
+        console.error(err);
+        return;
+    }
+    console.log('Apply with all options result:', result);
+});
+
+// Test applyToFile
+stylesheet1.applyToFile('./test/resources/cd.xml', (err, result) => {
+    if (err) {
+        console.error(err);
+        return;
+    }
+    if (typeof result === 'string') {
+        console.log('ApplyToFile result:', result);
+    }
+});
+
+// Test applyToFile with parameters
+stylesheet1.applyToFile('./test/resources/cd.xml', params, (err, result) => {
+    if (err) {
+        console.error(err);
+        return;
+    }
+    if (typeof result === 'string') {
+        console.log('ApplyToFile with params result:', result);
+    }
+});
+
+// Test applyToFile with all options
+stylesheet1.applyToFile('./test/resources/cd.xml', params, options, (err, result) => {
+    if (err) {
+        console.error(err);
+        return;
+    }
+    if (typeof result === 'string') {
+        console.log('ApplyToFile with all options result:', result);
+    }
+});
+
+console.log('All TypeScript type checks passed!');

--- a/types/libxmljs2.d.ts
+++ b/types/libxmljs2.d.ts
@@ -1,0 +1,107 @@
+// Minimal type definitions for libxmljs2
+// Based on libxmljs2 API
+
+declare module "libxmljs2" {
+    export interface ParserOptions {
+        noblanks?: boolean;
+        noent?: boolean;
+        nocdata?: boolean;
+        noerror?: boolean;
+        nowarning?: boolean;
+        pedantic?: boolean;
+        nonet?: boolean;
+        nocompact?: boolean;
+        dtdload?: boolean;
+        dtdattr?: boolean;
+        dtdvalid?: boolean;
+        nobasefix?: boolean;
+        huge?: boolean;
+        oldsax?: boolean;
+        ignorenc?: boolean;
+        biglines?: boolean;
+    }
+
+    export interface Node {
+        doc(): Document;
+        parent(): Node | null;
+        namespace(): Namespace | null;
+        namespacePrefix(): string | null;
+        namespaceHref(): string | null;
+        type(): string;
+        name(): string;
+        text(): string;
+        text(text: string): Node;
+        toString(): string;
+        remove(): void;
+    }
+
+    export interface Element extends Node {
+        name(): string;
+        name(name: string): Element;
+        attr(name: string): Attribute | null;
+        attr(attr: Attribute): Element;
+        attr(name: string, value: string): Element;
+        attrs(): Attribute[];
+        child(idx: number): Node | null;
+        childNodes(): Node[];
+        addChild(child: Node): Node;
+        node(name: string): Element;
+        node(name: string, content: string): Element;
+        text(): string;
+        text(text: string): Element;
+        find(xpath: string): Node[];
+        get(xpath: string): Node | null;
+    }
+
+    export interface Attribute {
+        name(): string;
+        namespace(): Namespace | null;
+        value(): string;
+        value(value: string): Attribute;
+        node(): Element;
+        remove(): void;
+    }
+
+    export interface Namespace {
+        href(): string;
+        prefix(): string;
+    }
+
+    export interface Document {
+        root(): Element | null;
+        root(node: Element): Document;
+        encoding(): string;
+        encoding(encoding: string): Document;
+        version(): string;
+        find(xpath: string): Node[];
+        get(xpath: string): Node | null;
+        node(name: string): Element;
+        toString(): string;
+        validate(schema: Document): boolean;
+    }
+
+    export interface SyntaxError {
+        message: string;
+        code: number;
+        line: number;
+        column: number;
+        level: number;
+        file: string | null;
+    }
+
+    export function parseXml(source: string, options?: ParserOptions): Document;
+    export function parseHtml(source: string, options?: ParserOptions): Document;
+    export function parseHtmlFragment(source: string, options?: ParserOptions): Document;
+
+    export const version: string;
+    export const libxml_version: string;
+    export const libxml_parser_version: string;
+    export const libxml_debug_enabled: boolean;
+
+    export function memoryUsage(): number;
+    export function nodeCount(): number;
+
+    export class Comment extends Node {}
+    export class Text extends Node {}
+    export class ProcessingInstruction extends Node {}
+}


### PR DESCRIPTION
## Summary
- Fixed installation failures when the package is installed in directories containing spaces
- Replaced gyp variable expansion with direct Node.js command execution for path resolution
- Added comprehensive test coverage for spaces-in-path scenarios

## Technical Details
The root cause was that gyp's `<(variable)` expansion mechanism generated unquoted paths in Makefiles, causing build failures when paths contained spaces. The solution replaces this with `<\!(node -p ...)` syntax which:

1. **Executes at configuration time**: Paths are resolved when gyp generates the Makefile
2. **Properly handles spaces**: Node's `path.join()` ensures correct path construction  
3. **Avoids escaping complexity**: No nested quoting issues with variable expansion

## Changes Made
- **common.gypi**: Replaced `<(node_xmljs)` variable expansion with direct `<\!(node -p ...)` commands
- **package.json**: Bumped version to 1.0.9
- **test/spaces-in-path.js**: Added comprehensive test for installation in paths with spaces

## Test Results
✅ All existing tests pass  
✅ New spaces-in-path test passes  
✅ Package successfully installs and loads in directories with spaces

## Testing
```bash
npm run test:spaces
npm test
```