### PR TITLE
Fix #4: run async parse/apply on the main thread (no worker-thread races)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,38 +153,30 @@ var result = stylesheet.apply(documentString);
 
 ```
 
-The asynchronous functions use the [libuv work queue](http://nikhilm.github.io/uvbook/threads.html#libuv-work-queue)
-to provide parallelized computation in node.js worker threads. This makes it non-blocking for the main event loop of node.js.
+When a callback is given, *parse()* and *apply()* run the transform on the main
+thread but invoke the callback on a later tick of the event loop (via
+`setImmediate`). The call returns immediately and errors are delivered to the
+callback instead of being thrown.
 
-Note that libxmljs parsing doesn't use the work queue, so only a part of the process is actually parallelized.
+> **Note on parallelism:** earlier versions ran the libxslt computation on a
+> libuv worker thread. That was removed because libxslt/libxml2 share global
+> state with libxmljs2 and are not safe to run off the main thread, which caused
+> intermittent empty results and crashes. The callback form therefore does **not**
+> parallelize CPU work across threads — it only defers it. If you need true
+> parallelism for CPU-bound transforms, run libxslt-next inside your own
+> [`worker_threads`](https://nodejs.org/api/worker_threads.html) pool.
 
-A small benchmark is available in the project. It has a very limited scope, it uses always the same small transformation a few thousand times.
-To run it use:
+A small benchmark is available in the project (it always runs the same small
+transformation a few thousand times):
 
     node benchmark.js
 
-This is an example of its results with an intel core i5 3.1GHz:
-
-```
-10000 synchronous parse from parsed doc                in 52ms = 192308/s
-10000 asynchronous parse in series from parsed doc     in 229ms = 43668/s
-10000 asynchronous parse in parallel from parsed doc   in 56ms = 178571/s
-10000 synchronous apply from parsed doc                in 329ms = 30395/s
-10000 asynchronous apply in series from parsed doc     in 569ms = 17575/s
-10000 asynchronous apply in parallel from parsed doc   in 288ms = 34722/s
-
-```
-
-Observations:
-  - it's pretty fast !
-  - asynchronous is slower when running in series.
-  - asynchronous can become faster when concurrency is high.
-
-Conclusion:
-  - use asynchronous by default it will be kinder to your main event loop and is pretty fast anyway.
-  - use synchronous only if you really want the highest performance and expect low concurrency.
-  - of course you can also use synchronous simply to reduce code depth. If you don't expect a huge load it will be ok.
-  - DO NOT USE synchronous parsing if there is some includes in your XSL stylesheets.
+Guidance:
+  - the synchronous and callback forms do the same amount of work; the callback
+    form only differs in that it yields to the event loop before running.
+  - of course you can use synchronous simply to reduce code depth.
+  - DO NOT USE synchronous parsing if there are includes in your XSL stylesheets
+    (include resolution makes parsing IO-bound).
 
 Environment compatibility
 -------------------------

--- a/index.js
+++ b/index.js
@@ -50,8 +50,18 @@ exports.parse = function(source, callback) {
 	}
 
 	if (callback) {
-		binding.stylesheetAsync(source, function(err, stylesheet){
-			if (err) return callback(err);
+		// Run on the main thread, deferred. libxslt/libxml2 share process- and
+		// thread-global state with libxmljs2; parsing a stylesheet on a libuv
+		// worker thread while the main thread uses libxml2 races and intermittently
+		// yields a corrupt result or crashes. The synchronous path is reliable, so
+		// defer to it to keep the callback (non-blocking-call) contract. See #4.
+		setImmediate(function() {
+			var stylesheet;
+			try {
+				stylesheet = binding.stylesheetSync(source);
+			} catch (err) {
+				return callback(err);
+			}
 			callback(null, new Stylesheet(source, stylesheet));
 		});
 	} else {
@@ -155,8 +165,19 @@ Stylesheet.prototype.apply = function(source, params, options, callback) {
 	var docResult = new libxmljs.Document();
 
 	if (callback) {
-		binding.applyAsync(this.stylesheetObj, source, paramsArray, outputString, docResult, function(err, strResult){
-			if (err) return callback(err);
+		// Run on the main thread, deferred. Applying a stylesheet on a libuv worker
+		// thread shares the stylesheet and libxslt/libxml2 global state with the
+		// main thread (and libxmljs2), which races and intermittently produces an
+		// empty result or a segfault. The synchronous path is reliable, so defer to
+		// it to keep the callback (non-blocking-call) contract. See #4.
+		var self = this;
+		setImmediate(function() {
+			var strResult;
+			try {
+				strResult = binding.applySync(self.stylesheetObj, source, paramsArray, outputString, docResult);
+			} catch (err) {
+				return callback(err);
+			}
 			callback(null, outputString ? strResult : docResult);
 		});
 	} else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libxslt-next",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Node.js bindings for libxslt with Node.js 22/24 support - Modern fork with updated dependencies",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
## Problem
The callback forms of `parse()` and `apply()` ran libxslt on a **libuv worker thread** (`StylesheetWorker` / `ApplyWorker`). libxslt and libxml2 share process- and thread-global state with libxmljs2 and are not safe to run off the main thread while the main thread also uses libxml2. Depending on timing this:
- corrupted the output → intermittent **empty results** (`expected '' to match …`), or
- freed memory still in use → **SIGSEGV** (exit 139).

Both are the flaky CI failures tracked in #4.

## Fix
Route the callback forms through the **synchronous** bindings on the **main thread**, deferred via `setImmediate`:
- `parse(src, cb)` → `binding.stylesheetSync` inside `setImmediate`
- `apply(..., cb)` → `binding.applySync` inside `setImmediate`

The call still returns immediately and errors are delivered to the callback.

**Why this is correct:** async now issues the *exact same* libxslt calls as the synchronous path — same thread, same source document — so it becomes the path that has never flaked. The thread boundary (the only real difference between the two) is removed.

## Trade-off
The callback forms no longer parallelize CPU work across threads — they only defer it. Safe worker-thread execution isn't achievable here (we can't serialize libxmljs2's own main-thread libxml2 calls from our worker), and the benchmark already showed async-in-series slower than sync, so the loss is marginal. The README "Sync or async" section is updated, pointing users to `worker_threads` for true parallelism.

## Verification
- `npm install` builds clean; full suite **37 passing**.
- Async tests: **0 failures across 20 local runs** (supplementary; the structural argument above is the real proof).

## Notes
- Semver-relevant behavior change → bumped to **1.0.11**.
- Native code is untouched; the now-unused `StylesheetWorker`/`ApplyWorker` classes and the `stylesheetAsync`/`applyAsync` exports can be removed in a follow-up.
- The sibling hazard in async **parse** (`StylesheetWorker`) is fixed here too, not just apply.

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)