### PR TITLE
Fix #5: build works in install paths containing spaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,9 @@ jobs:
     - name: Test module loading
       run: node -e "console.log('✅ Module loads:', !!require('./index.js'))"
 
+    - name: Build and load in a path containing spaces
+      run: npm run test:spaces
+
   alpine-musl:
     # Regression test for ERR_DLOPEN_FAILED on musl (Alpine): node-libxslt.node
     # links xmljs.node by basename, which musl resolves via the runtime library

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,8 @@ jobs:
       run: npm run test:spaces
 
   spaces-windows:
-    # Experiment: does a fresh build in a spaced directory work on Windows?
+    # Spaced-path build on Windows. The msvs/MSBuild generator quotes paths, so
+    # (unlike the make generator) spaces work here; this guards that.
     runs-on: windows-2022
     steps:
     - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,23 @@ jobs:
     - name: Build and load in a path containing spaces
       run: npm run test:spaces
 
+  spaces-windows:
+    # Experiment: does a fresh build in a spaced directory work on Windows?
+    runs-on: windows-2022
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+    - name: Use Node.js 22.x
+      uses: actions/setup-node@v4
+      with:
+        node-version: 22.x
+    - name: Install dependencies
+      run: npm install
+    - name: Build and load in a path containing spaces
+      run: npm run test:spaces
+
   alpine-musl:
     # Regression test for ERR_DLOPEN_FAILED on musl (Alpine): node-libxslt.node
     # links xmljs.node by basename, which musl resolves via the runtime library

--- a/README.md
+++ b/README.md
@@ -1,14 +1,20 @@
 libxslt-next
 ============
 
-[![Build status](https://travis-ci.org/albanm/node-libxslt.svg)](https://travis-ci.org/albanm/node-libxslt)
-[![Code Climate](https://codeclimate.com/github/albanm/node-libxslt/badges/gpa.svg)](https://codeclimate.com/github/albanm/node-libxslt)
-[![NPM version](https://badge.fury.io/js/libxslt-next.svg)](http://badge.fury.io/js/libxslt-next)
+[![CI](https://github.com/mariuso/node-libxslt-next/actions/workflows/ci.yml/badge.svg)](https://github.com/mariuso/node-libxslt-next/actions/workflows/ci.yml)
+[![npm version](https://img.shields.io/npm/v/libxslt-next.svg)](https://www.npmjs.com/package/libxslt-next)
+[![node](https://img.shields.io/node/v/libxslt-next.svg)](https://www.npmjs.com/package/libxslt-next)
+[![license](https://img.shields.io/npm/l/libxslt-next.svg)](./LICENSE)
 
-Node.js bindings for [libxslt](http://xmlsoft.org/libxslt/) compatible with [libxmljs2](https://github.com/libxmljs/libxmljs2).
+Node.js bindings for [libxslt](http://xmlsoft.org/libxslt/), compatible with [libxmljs2](https://github.com/libxmljs/libxmljs2).
 
-> **⚡ Node.js Compatibility Update**: This version supports Node.js 22.x and 24.x LTS versions.
-> For users upgrading from Node.js 20 or earlier versions, this package now uses modern dependencies and APIs for improved compatibility and performance.
+A modern, maintained fork of [node-libxslt](https://github.com/albanm/node-libxslt) with updated
+dependencies, TypeScript types, and support for current Node.js LTS releases.
+
+- **Node.js 22.x and 24.x** (Node 20 is not supported — `libxmljs2@0.37` requires Node ≥ 22)
+- **Linux (glibc & musl/Alpine), macOS (Intel & Apple Silicon), Windows** — all built from source
+- **TypeScript types** included
+- Install paths containing spaces are supported (Linux, macOS and Windows)
 
 Installation
 ------------
@@ -17,14 +23,22 @@ Installation
 
 From source:
 
-    git clone https://github.com/mariuso/node-libxslt-next.git
-		git submodule update --init
-		npm install
-		npm test
+```sh
+git clone https://github.com/mariuso/node-libxslt-next.git
+cd node-libxslt-next
+git submodule update --init
+npm install
+npm test
+```
 
-**Manual Rebuild**: If you need to rebuild the native bindings manually:
+**Manual rebuild**: if you need to rebuild the native bindings:
 
-    npm run rebuild
+```sh
+npm run rebuild
+```
+
+The native addon is compiled on install, so a C/C++ toolchain and Python 3 must be
+present (see [Environment compatibility](#environment-compatibility) below).
 
 ### Alpine / musl
 

--- a/common.gypi
+++ b/common.gypi
@@ -4,12 +4,22 @@
     # Directory of the installed libxmljs2 package. Used on Windows to build its
     # xmljs addon into our PRODUCT_DIR so xmljs.lib is available to link against.
     'node_xmljs': '<!(node -p "require(\'path\').dirname(require.resolve(\'libxmljs2\'))")',
+    # Same directory, but RELATIVE to the project root. gyp writes absolute paths
+    # into the build files unquoted, so an absolute path containing spaces (e.g.
+    # an install dir like "/x/sp ace/proj") breaks the compiler/linker. A relative
+    # path stays under node_modules (no spaces) regardless of the parent dir. See #5.
+    'node_xmljs_rel': '<!(node -p "var p=require(\'path\'); p.relative(process.cwd(), p.dirname(require.resolve(\'libxmljs2\')))")',
+    'build_type%': "<!(node -p \"process.env.npm_config_build_type || 'Release'\")",
+    # Path from this addon's build/Release to libxmljs2's build/Release, used as
+    # an $ORIGIN-relative rpath. Computed (not hardcoded) so it is correct for
+    # hoisted, nested and pnpm layouts, and relative so it stays space-safe.
+    'xmljs_rpath_rel': '<!(node -p "var p=require(\'path\'); p.relative(p.join(process.cwd(), \'build\', \'Release\'), p.join(p.dirname(require.resolve(\'libxmljs2\')), \'build\', \'Release\'))")',
   },
   'target_defaults': {
     'include_dirs': [
-      '<!(node -p "require(\'path\').join(require(\'path\').dirname(require.resolve(\'libxmljs2\')), \'src\')")',
-      '<!(node -p "require(\'path\').join(require(\'path\').dirname(require.resolve(\'libxmljs2\')), \'vendor\', \'libxml\')")',
-      '<!(node -p "require(\'path\').join(require(\'path\').dirname(require.resolve(\'libxmljs2\')), \'vendor\', \'libxml\', \'include\')")'
+      '<(node_xmljs_rel)/src',
+      '<(node_xmljs_rel)/vendor/libxml',
+      '<(node_xmljs_rel)/vendor/libxml/include'
     ],
     'conditions': [
       ['OS=="win"', {
@@ -19,25 +29,28 @@
         # avoids the xmljs dependency target trying to link against itself.
       }, {
         'libraries': [
-          '<!(node -p "require(\'path\').join(require(\'path\').dirname(require.resolve(\'libxmljs2\')), \'build\', process.env.npm_config_build_type || \'Release\', \'xmljs.node\')")'
+          # gyp auto-prefixes library_dirs with $(srcdir) but not a libraries
+          # file input, so add it ourselves. srcdir is a relative path ("..") in
+          # the generated Makefile, so this stays space-safe. (make generator,
+          # i.e. Linux/macOS; Windows links via binding.gyp.)
+          '$(srcdir)/<(node_xmljs_rel)/build/<(build_type)/xmljs.node'
         ],
         'library_dirs': [
-          '<!(node -p "require(\'path\').join(require(\'path\').dirname(require.resolve(\'libxmljs2\')), \'build\', process.env.npm_config_build_type || \'Release\')")'
+          '<(node_xmljs_rel)/build/<(build_type)'
         ],
         'conditions': [
           # node-libxslt.node records a DT_NEEDED on the basename "xmljs.node".
           # glibc resolves that against the already-loaded libxmljs2 (index.js
           # requires libxmljs2 before this addon), so it works without an rpath.
           # musl (Alpine) instead resolves the basename via the runtime library
-          # path, which has no entry for it -> ERR_DLOPEN_FAILED. Add an rpath so
-          # the loader can find xmljs.node on musl. Both an absolute path (the
-          # build-time location) and an $ORIGIN-relative path (survives moving
-          # node_modules) are provided. macOS uses @loader_path instead of
-          # $ORIGIN and already works like glibc, so this is Linux-only.
+          # path, which has no entry for it -> ERR_DLOPEN_FAILED. Add an
+          # $ORIGIN-relative rpath so the loader finds xmljs.node on musl. An
+          # absolute rpath would break in install paths containing spaces (#5);
+          # $ORIGIN keeps it relative and also survives moving node_modules.
+          # macOS uses @loader_path and already works like glibc, so Linux-only.
           ['OS=="linux"', {
             'ldflags': [
-              '-Wl,-rpath,<!(node -p "require(\'path\').join(require(\'path\').dirname(require.resolve(\'libxmljs2\')), \'build\', process.env.npm_config_build_type || \'Release\')")',
-              '-Wl,-rpath,\'$$ORIGIN/../../../libxmljs2/build/Release\'',
+              '-Wl,-rpath,\'$$ORIGIN/<(xmljs_rpath_rel)\'',
             ],
           }],
         ],

--- a/test/spaces-in-path.js
+++ b/test/spaces-in-path.js
@@ -7,14 +7,6 @@ const os = require('os');
 
 console.log('Testing package installation in path with spaces...');
 
-// Windows is skipped for now: a fresh build into a spaced directory there is a
-// separate concern (it also hits an EPERM on the loaded .node during cleanup),
-// and is not yet verified. The Linux/macOS path below exercises the real fix.
-if (process.platform === 'win32') {
-  console.log('Skipping spaces-in-path test on Windows (not yet supported).');
-  process.exit(0);
-}
-
 // Create a temporary directory with spaces in the name
 const testDirName = 'test with spaces';
 const testDir = path.join(os.tmpdir(), testDirName);

--- a/test/spaces-in-path.js
+++ b/test/spaces-in-path.js
@@ -7,6 +7,14 @@ const os = require('os');
 
 console.log('Testing package installation in path with spaces...');
 
+// Windows is skipped for now: a fresh build into a spaced directory there is a
+// separate concern (it also hits an EPERM on the loaded .node during cleanup),
+// and is not yet verified. The Linux/macOS path below exercises the real fix.
+if (process.platform === 'win32') {
+  console.log('Skipping spaces-in-path test on Windows (not yet supported).');
+  process.exit(0);
+}
+
 // Create a temporary directory with spaces in the name
 const testDirName = 'test with spaces';
 const testDir = path.join(os.tmpdir(), testDirName);
@@ -39,21 +47,30 @@ try {
   
   console.log(`Installing ${currentPackageJson.name}@${currentPackageJson.version} from ${packagePath}...`);
 
-  // Install the current package in the test directory
-  execSync(`npm install "${packagePath}"`, {
+  // Install the current package in the test directory.
+  // --install-links copies the package and BUILDS it inside the (spaced) test
+  // directory, instead of symlinking back to the no-spaces source and rebuilding
+  // there. Without it this test never actually compiled against a spaced path
+  // and so could not catch the bug it is meant to guard (see #5).
+  execSync(`npm install --install-links "${packagePath}"`, {
     cwd: testDir,
     stdio: 'inherit',
-    timeout: 120000 // 2 minutes timeout
+    timeout: 300000 // 5 minutes (a full from-source build)
   });
 
-  // Try to require the installed package
+  // Require the installed package and run a real transform to confirm the native
+  // module compiled, links against libxmljs2, and works from the spaced path.
   const installedPackagePath = path.join(testDir, 'node_modules', currentPackageJson.name);
-  console.log(`Testing require from: ${installedPackagePath}`);
-  
-  // This will verify that the native module compiled and can be loaded
-  require(installedPackagePath);
-  
-  console.log('✅ SUCCESS: Package installed and loaded successfully in path with spaces!');
+  console.log(`Testing require + transform from: ${installedPackagePath}`);
+
+  const libxslt = require(installedPackagePath);
+  const stylesheet = libxslt.parse('<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:template match="/"><out><xsl:value-of select="/in/@v"/></out></xsl:template></xsl:stylesheet>');
+  const result = stylesheet.apply('<in v="spaces-ok"/>');
+  if (result.indexOf('spaces-ok') === -1) {
+    throw new Error('transform produced unexpected output: ' + result);
+  }
+
+  console.log('✅ SUCCESS: built, loaded and transformed in a path with spaces!');
 
 } catch (error) {
   console.error('❌ FAILED: Error during spaces-in-path test:');


### PR DESCRIPTION
## Problem
gyp writes absolute paths into the generated build files **unquoted**, so when the install path contains a space (e.g. `.../sp ace/proj`) the compiler/linker split the flag and fail:

```
clang: error: no such file or directory: 'with'
clang: error: no such file or directory: 'ace/proj/node_modules/libxmljs2/src'
```

Every offending path in `common.gypi` was absolute (derived from `require.resolve('libxmljs2')`). This affects the **make generator** (Linux/macOS); Windows (msvs/MSBuild) quotes paths and was already fine.

## Fix
Make the paths **relative** — a relative path stays under `node_modules` (no spaces) regardless of the parent directory:
- `include_dirs` / `library_dirs` use a `node_xmljs_rel` variable (relative to the project root); gyp re-relativizes them to the build dir → `-I$(srcdir)/node_modules/...`.
- the `libraries` file input is prefixed with `$(srcdir)` (a relative `..` in the Makefile), since gyp auto-prefixes `library_dirs` but not file inputs.
- the Linux rpath becomes a single **`$ORIGIN`-relative** entry, *computed* from the addon's build dir to libxmljs2's build dir. This replaces both the absolute rpath (broke on spaces) and the hardcoded `../../../` one (assumed a hoisted layout). The computed value is correct for hoisted, nested and pnpm layouts and is space-safe.

`test/spaces-in-path.js` now actually exercises a spaced build (`npm install --install-links` builds the package *inside* the spaced dir instead of symlinking to the no-spaces source), runs a real transform, and is wired into CI on **Linux (build-test job), macOS (verified locally) and Windows (spaces-windows job)**.

## Verification
- **macOS normal build**: 37 passing (no regression).
- **macOS spaced build**: loads + transforms.
- **Alpine/musl spaced build** (podman): correct `$ORIGIN` rpath for **both** self-build (`$ORIGIN/../../node_modules/libxmljs2/...`) and installed-as-dependency (`$ORIGIN/../../../libxmljs2/...`) layouts.
- **Windows spaced build** (CI `spaces-windows` job): builds and transforms in `...\Temp\test with spaces\...` — confirms Windows already handled spaces (MSBuild quotes paths).

## Notes
- **No version bump** here to avoid colliding with #6 (which bumps to 1.0.11); set the release version at merge time.
- Also refreshes the README (badges, intro, From-source block). Avoids the "Sync or async" section (owned by #6) and the generated API reference, so no conflict with #6.

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)